### PR TITLE
fix: Ellipsis nodes cannot be deleted correctly when nesting exists

### DIFF
--- a/src/shave.ts
+++ b/src/shave.ts
@@ -51,7 +51,11 @@ export default function shave(target: string | NodeList, maxHeight: number, opts
     // If element text has already been shaved
     if (span) {
       // Remove the ellipsis to recapture the original text
-      el.removeChild(el.querySelector(`.${charclassname}`))
+      const charList = el.querySelectorAll(`.${charclassname}`)
+      for (let i = 0; i < charList.length; i++) {
+        const char = charList[i]
+        char.parentNode.removeChild(char)
+      }
       el[textProp] = el[textProp] // eslint-disable-line
       // nuke span, recombine text
     }


### PR DESCRIPTION
## Fixes

- [removeChild](https://developer.mozilla.org/zh-CN/docs/Web/API/Node/removeChild) can only delete child nodes, not grandchildren and deeper nodes. Therefore, when there is a nested relationship, it will report an error. Beacuse `el.removeChild(el.querySelector('.'+charclassname))` cannot guarantee that the obtained node must be a child node of `el`.


## Proposed Changes

- Change

----

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.
