### PR TITLE
fix: Compatible with innerText and textcontent

### DIFF
--- a/src/shave.ts
+++ b/src/shave.ts
@@ -56,6 +56,15 @@ export default function shave(target: string | NodeList, maxHeight: number, opts
         const char = charList[i]
         char.parentNode.removeChild(char)
       }
+      // innerText could not get the invisible element (such as 'display: none;'),so it special treatment is required.
+      if (textProp === 'innerText') {
+        const elWithShavedTextList = el.querySelectorAll(`.${classname}`)
+        for (let i = 0; i < elWithShavedTextList.length; i++) {
+          const elWithShavedText = elWithShavedTextList[i] as HTMLElement
+          elWithShavedText.style.display = null
+          elWithShavedText.style.fontSize = '0px'
+        }
+      }
       el[textProp] = el[textProp] // eslint-disable-line
       // nuke span, recombine text
     }


### PR DESCRIPTION
## Fixes

- Because shape hide the overflow text by using `display: none;`. At this time, if `innerText` is used, these overflow text cannot be obtained. 
- [textContent returns every element in the node. In contrast, innerText is aware of styling and won't return the text of "hidden" elements.](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent)


## Proposed Changes

- Change

----

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.
